### PR TITLE
Add OpenAI reviewer service boundary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,13 @@
 GITHUB_TOKEN=secret_pat_token
 GITHUB_WEBHOOK_SECRET=secret_webhook_token
 
+# Review generation
+REVIEW_PROVIDER=deterministic
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4.1-mini
+OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_TIMEOUT_SECONDS=30
+
 # Application configuration
 APP_ENV=development
 APP_HOST=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ GitHub --> /webhook --> review_jobs (SQLite) --> worker --> GitHub PR comment
 | Review jobs | `app/review_jobs.py` | Review job repository, dedup, claim, complete, and fail transitions |
 | Worker | `app/worker.py` | Claim pending jobs, fetch PR data, post structured summary comments, and mark job status |
 | GitHub client | `app/github_client.py` | GitHub REST API wrapper for pull request fetch and PR comment posting |
-| Reviewer | `app/reviewer.py` | Deterministic top-level review summary generation from PR metadata and changed files |
+| Reviewer | `app/reviewer.py` | Build review inputs, invoke the configured reviewer service, and format fallback comments |
+| Review service | `app/review_service.py` | Dedicated review generator interface and OpenAI-backed implementation |
 | Config | `app/config.py` | `pydantic-settings` based env and `.env` loading |
 | Logging | `app/logging_config.py` | Structured JSON logging via `structlog` |
 
@@ -61,6 +62,11 @@ Edit `.env` and fill in:
 |---|---|---|
 | `GITHUB_TOKEN` | Personal access token used for GitHub API calls | Yes |
 | `GITHUB_WEBHOOK_SECRET` | Secret configured on the GitHub webhook | No |
+| `REVIEW_PROVIDER` | `deterministic` or `openai` | No |
+| `OPENAI_API_KEY` | API key used when `REVIEW_PROVIDER=openai` | Only for OpenAI mode |
+| `OPENAI_MODEL` | OpenAI model name for review generation | No |
+| `OPENAI_BASE_URL` | Base URL for the OpenAI-compatible API | No |
+| `OPENAI_TIMEOUT_SECONDS` | Timeout for OpenAI API calls | No |
 | `APP_ENV` | `development` or `production` | No |
 | `APP_HOST` | Bind host | No |
 | `APP_PORT` | Bind port | No |
@@ -128,6 +134,11 @@ The worker polls for the oldest `pending` job, marks it `processing`, fetches
 the pull request and changed files from GitHub, generates a structured review
 summary comment, and then marks the job `completed` or `failed`.
 
+By default, review generation stays deterministic. Set `REVIEW_PROVIDER=openai`
+and provide `OPENAI_API_KEY` to enable the OpenAI-backed reviewer. If the API
+call fails or returns an invalid payload, PRahari logs the error and falls back
+to the deterministic review summary instead of failing the job.
+
 ---
 
 ## Running tests
@@ -155,6 +166,7 @@ PRahari/
 |   |   `-- 001_create_review_jobs.sql
 |   |-- review_jobs.py
 |   |-- reviewer.py
+|   |-- review_service.py
 |   |-- webhook.py
 |   `-- worker.py
 |-- tests/
@@ -163,6 +175,7 @@ PRahari/
 |   |-- test_health.py
 |   |-- test_review_jobs.py
 |   |-- test_reviewer.py
+|   |-- test_review_service.py
 |   |-- test_webhook.py
 |   `-- test_worker.py
 |-- .env.example
@@ -178,6 +191,6 @@ PRahari/
 
 ## What is not implemented yet
 
-- OpenAI-powered review generation
+- Repository-local prompt files and richer review policy controls
 - Richer inline review comments beyond the top-level structured summary
 - Authentication and multi-tenant support

--- a/app/config.py
+++ b/app/config.py
@@ -8,7 +8,7 @@ class Settings(BaseSettings):
     """All runtime settings for PRahari."""
 
     model_config = SettingsConfigDict(
-        env_file=".env.example",
+        env_file=".env",
         env_file_encoding="utf-8",
         extra="ignore",
     )
@@ -16,6 +16,13 @@ class Settings(BaseSettings):
     # GitHub
     github_token: str = ""
     github_webhook_secret: str = ""
+
+    # Review generation
+    review_provider: str = "deterministic"
+    openai_api_key: str = ""
+    openai_model: str = "gpt-4.1-mini"
+    openai_base_url: str = "https://api.openai.com/v1"
+    openai_timeout_seconds: float = 30.0
 
     # Application
     app_env: str = "development"

--- a/app/review_service.py
+++ b/app/review_service.py
@@ -1,0 +1,171 @@
+"""LLM-backed review generation services and shared review data models."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import httpx
+
+from app.config import settings
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class ReviewGenerationError(RuntimeError):
+    """Raised when a review generator cannot return a usable result."""
+
+
+@dataclass(slots=True)
+class ReviewInput:
+    """Structured PR context passed into the review generator."""
+
+    pr_number: int | None
+    title: str
+    body: str
+    additions: int
+    deletions: int
+    changed_files: list[str]
+    head_sha: str
+
+
+@dataclass(slots=True)
+class ReviewSections:
+    """Normalized review output returned by a review generator."""
+
+    summary: str
+    findings: list[str]
+    open_questions: list[str]
+
+
+class ReviewGenerator(Protocol):
+    """Interface for generating structured review sections."""
+
+    async def generate(self, review_input: ReviewInput) -> ReviewSections:
+        """Return review sections for the provided PR context."""
+
+
+class OpenAIReviewGenerator:
+    """Generate PR review sections using the OpenAI Chat Completions API."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> None:
+        self._api_key = api_key or settings.openai_api_key
+        self._model = model or settings.openai_model
+        self._base_url = (base_url or settings.openai_base_url).rstrip("/")
+        self._timeout_seconds = timeout_seconds or settings.openai_timeout_seconds
+
+    async def generate(self, review_input: ReviewInput) -> ReviewSections:
+        if not self._api_key:
+            raise ReviewGenerationError("OpenAI API key is not configured")
+
+        payload = {
+            "model": self._model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are reviewing a pull request. Return compact JSON with "
+                        "keys summary, findings, and open_questions. Keep findings and "
+                        "open_questions short and limited to at most 3 items each."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": self._build_prompt(review_input),
+                },
+            ],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "pr_review",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            "summary": {"type": "string"},
+                            "findings": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "open_questions": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                        },
+                        "required": ["summary", "findings", "open_questions"],
+                    },
+                },
+            },
+        }
+
+        try:
+            async with httpx.AsyncClient(
+                base_url=self._base_url,
+                timeout=self._timeout_seconds,
+            ) as client:
+                response = await client.post(
+                    "/chat/completions",
+                    headers={
+                        "Authorization": f"Bearer {self._api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                )
+            response.raise_for_status()
+            data = response.json()
+            content = data["choices"][0]["message"]["content"]
+            parsed = json.loads(content)
+            return ReviewSections(
+                summary=str(parsed["summary"]).strip(),
+                findings=_normalize_items(parsed["findings"]),
+                open_questions=_normalize_items(parsed["open_questions"]),
+            )
+        except httpx.HTTPError as exc:
+            logger.warning(
+                "review_service.openai.http_error",
+                error=str(exc),
+                model=self._model,
+            )
+            raise ReviewGenerationError(f"OpenAI request failed: {exc}") from exc
+        except (KeyError, IndexError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "review_service.openai.invalid_response",
+                error=str(exc),
+                model=self._model,
+            )
+            raise ReviewGenerationError("OpenAI returned an invalid review payload") from exc
+
+    def _build_prompt(self, review_input: ReviewInput) -> str:
+        changed_files = "\n".join(f"- {filename}" for filename in review_input.changed_files[:50])
+        body = review_input.body.strip() or "(no PR body provided)"
+        return (
+            f"PR #{review_input.pr_number or 'unknown'}\n"
+            f"Title: {review_input.title}\n"
+            f"Head SHA: {review_input.head_sha}\n"
+            f"Additions: {review_input.additions}\n"
+            f"Deletions: {review_input.deletions}\n"
+            f"Body:\n{body}\n\n"
+            f"Changed files:\n{changed_files or '- none reported'}"
+        )
+
+
+def build_review_generator() -> ReviewGenerator | None:
+    """Return the configured review generator, if one is enabled."""
+    if settings.review_provider == "openai":
+        return OpenAIReviewGenerator()
+    return None
+
+
+def _normalize_items(items: Any) -> list[str]:
+    if not isinstance(items, list):
+        raise TypeError("Expected a list of review items")
+    return [str(item).strip() for item in items if str(item).strip()][:3]

--- a/app/reviewer.py
+++ b/app/reviewer.py
@@ -1,26 +1,48 @@
-"""Deterministic PR review summary generation."""
+"""PR review orchestration and deterministic fallback generation."""
 from __future__ import annotations
 
 from collections import Counter
 from typing import Any
 
 from app.logging_config import get_logger
+from app.review_service import (
+    ReviewGenerator,
+    ReviewInput,
+    ReviewSections,
+    build_review_generator,
+)
 
 logger = get_logger(__name__)
 
 
-def build_review_comment(
+async def build_review_comment(
     pull_request: dict[str, Any],
     changed_files: list[dict[str, Any]],
     *,
     head_sha: str,
+    generator: ReviewGenerator | None = None,
 ) -> str:
-    """Build a structured top-level PR comment, with placeholder fallback."""
+    """Build a structured top-level PR comment with LLM and fallback support."""
+    review_input = _build_review_input(pull_request, changed_files, head_sha=head_sha)
+    review_generator = generator if generator is not None else build_review_generator()
+
+    if review_generator is not None:
+        try:
+            generated = await review_generator.generate(review_input)
+            return _format_review_comment(generated)
+        except Exception:
+            logger.exception(
+                "reviewer.build_review_comment.generator_failed",
+                pr_number=pull_request.get("number"),
+                head_sha=head_sha,
+            )
+
     try:
-        return _build_structured_review_comment(pull_request, changed_files)
+        generated = _build_structured_review_sections(review_input)
+        return _format_review_comment(generated)
     except Exception:
         logger.exception(
-            "reviewer.build_review_comment.failed",
+            "reviewer.build_review_comment.fallback_failed",
             pr_number=pull_request.get("number"),
             head_sha=head_sha,
         )
@@ -28,36 +50,59 @@ def build_review_comment(
 
 
 def build_placeholder_review_comment(head_sha: str) -> str:
-    """Return the existing placeholder comment body."""
+    """Return the placeholder comment body."""
     return f"Review pipeline connected successfully for this PR head SHA {head_sha}"
 
 
-def _build_structured_review_comment(
-    pull_request: dict[str, Any], changed_files: list[dict[str, Any]]
-) -> str:
-    title = str(pull_request.get("title") or "Untitled PR")
-    file_count = len(changed_files)
-    additions = int(pull_request.get("additions") or 0)
-    deletions = int(pull_request.get("deletions") or 0)
-    areas = _summarize_areas(changed_files)
-    findings = _derive_findings(changed_files, additions, file_count)
-    questions = _derive_questions(changed_files)
+def _build_review_input(
+    pull_request: dict[str, Any],
+    changed_files: list[dict[str, Any]],
+    *,
+    head_sha: str,
+) -> ReviewInput:
+    return ReviewInput(
+        pr_number=pull_request.get("number"),
+        title=str(pull_request.get("title") or "Untitled PR"),
+        body=str(pull_request.get("body") or ""),
+        additions=int(pull_request.get("additions") or 0),
+        deletions=int(pull_request.get("deletions") or 0),
+        changed_files=[str(file_info["filename"]) for file_info in changed_files],
+        head_sha=head_sha,
+    )
 
+
+def _build_structured_review_sections(review_input: ReviewInput) -> ReviewSections:
+    areas = _summarize_areas(review_input.changed_files)
+    findings = _derive_findings(
+        review_input.changed_files,
+        review_input.additions,
+        len(review_input.changed_files),
+    )
+    questions = _derive_questions(review_input.changed_files)
+
+    summary = (
+        f"{review_input.title}. This PR touches {len(review_input.changed_files)} file(s) "
+        f"with {review_input.additions} addition(s) and {review_input.deletions} deletion(s)."
+    )
+    if areas:
+        summary = f"{summary} Primary areas: {areas}."
+
+    return ReviewSections(
+        summary=summary,
+        findings=findings,
+        open_questions=questions,
+    )
+
+
+def _format_review_comment(sections: ReviewSections) -> str:
     lines = [
         "PRahari review summary",
         "",
         "Summary",
-        (
-            f"- {title}. This PR touches {file_count} file(s) "
-            f"with {additions} addition(s) and {deletions} deletion(s)."
-        ),
+        f"- {sections.summary}",
     ]
-
-    if areas:
-        lines.append(f"- Primary areas: {areas}.")
-
-    lines.extend(_format_section("Potential findings", findings))
-    lines.extend(_format_section("Open questions", questions))
+    lines.extend(_format_section("Potential findings", sections.findings))
+    lines.extend(_format_section("Open questions", sections.open_questions))
     return "\n".join(lines)
 
 
@@ -70,10 +115,9 @@ def _format_section(title: str, items: list[str]) -> list[str]:
     return lines
 
 
-def _summarize_areas(changed_files: list[dict[str, Any]]) -> str:
+def _summarize_areas(changed_files: list[str]) -> str:
     areas: list[str] = []
-    for file_info in changed_files:
-        filename = file_info["filename"]
+    for filename in changed_files:
         parts = filename.split("/", maxsplit=1)
         areas.append(parts[0] if len(parts) > 1 else filename)
 
@@ -82,19 +126,18 @@ def _summarize_areas(changed_files: list[dict[str, Any]]) -> str:
 
 
 def _derive_findings(
-    changed_files: list[dict[str, Any]], additions: int, file_count: int
+    changed_files: list[str], additions: int, file_count: int
 ) -> list[str]:
-    filenames = [file_info["filename"] for file_info in changed_files]
     findings: list[str] = []
 
-    if filenames and not any("test" in filename.lower() for filename in filenames):
+    if changed_files and not any("test" in filename.lower() for filename in changed_files):
         findings.append(
             "No test file changes were detected; verify the affected paths with focused checks."
         )
 
     if any(
         token in filename.lower()
-        for filename in filenames
+        for filename in changed_files
         for token in ("migration", ".sql", "config", ".env", "docker")
     ):
         findings.append(
@@ -109,18 +152,28 @@ def _derive_findings(
     return findings[:3]
 
 
-def _derive_questions(changed_files: list[dict[str, Any]]) -> list[str]:
-    filenames = [file_info["filename"] for file_info in changed_files]
+def _derive_questions(changed_files: list[str]) -> list[str]:
     questions: list[str] = []
 
-    if any(token in filename.lower() for filename in filenames for token in ("worker", "queue", "review")):
+    if any(
+        token in filename.lower()
+        for filename in changed_files
+        for token in ("worker", "queue", "review")
+    ):
         questions.append("Should retry behavior or stale-job handling change for this path?")
 
-    if any(token in filename.lower() for filename in filenames for token in ("migration", ".sql", "database")):
+    if any(
+        token in filename.lower()
+        for filename in changed_files
+        for token in ("migration", ".sql", "database")
+    ):
         questions.append("Does this schema change require deployment ordering or backfill steps?")
 
-    if any(token in filename.lower() for filename in filenames for token in ("config", ".env", "docker")):
+    if any(
+        token in filename.lower()
+        for filename in changed_files
+        for token in ("config", ".env", "docker")
+    ):
         questions.append("Are there operator-facing configuration updates that should be documented?")
 
     return questions[:3]
-

--- a/app/worker.py
+++ b/app/worker.py
@@ -34,7 +34,7 @@ async def process_review_job(
     try:
         pull_request = await github.get_pull_request(owner, repo_name, job.pr_number)
         changed_files = await github.list_pull_request_files(owner, repo_name, job.pr_number)
-        comment_body = build_review_comment(
+        comment_body = await build_review_comment(
             pull_request,
             changed_files,
             head_sha=job.head_sha,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,8 @@ def test_default_settings() -> None:
     assert s.worker_poll_interval == 5
     assert s.log_level == "INFO"
     assert s.database_path == "data/prahari.db"
+    assert s.review_provider == "deterministic"
+    assert s.openai_model == "gpt-4.1-mini"
 
 
 def test_settings_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -21,6 +23,9 @@ def test_settings_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LOG_LEVEL", "DEBUG")
     monkeypatch.setenv("GITHUB_TOKEN", "tok123")
     monkeypatch.setenv("DATABASE_PATH", "tmp/test.db")
+    monkeypatch.setenv("REVIEW_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4.1")
 
     s = Settings()
     assert s.app_env == "production"
@@ -28,3 +33,6 @@ def test_settings_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert s.log_level == "DEBUG"
     assert s.github_token == "tok123"
     assert s.database_path == "tmp/test.db"
+    assert s.review_provider == "openai"
+    assert s.openai_api_key == "openai-secret"
+    assert s.openai_model == "gpt-4.1"

--- a/tests/test_review_service.py
+++ b/tests/test_review_service.py
@@ -1,0 +1,109 @@
+"""Tests for the OpenAI-backed review service boundary."""
+from __future__ import annotations
+
+import pytest
+
+import app.review_service as review_service
+from app.review_service import OpenAIReviewGenerator, ReviewGenerationError, ReviewInput
+
+
+class FakeResponse:
+    def __init__(self, payload: dict, *, raise_error: Exception | None = None) -> None:
+        self._payload = payload
+        self._raise_error = raise_error
+
+    def raise_for_status(self) -> None:
+        if self._raise_error is not None:
+            raise self._raise_error
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class FakeAsyncClient:
+    response = FakeResponse(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": (
+                            '{"summary":"LLM summary","findings":["One"],'
+                            '"open_questions":["Question?"]}'
+                        )
+                    }
+                }
+            ]
+        }
+    )
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.base_url = kwargs.get("base_url")
+        self.timeout = kwargs.get("timeout")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def post(self, path: str, *, headers: dict, json: dict) -> FakeResponse:
+        self.path = path
+        self.headers = headers
+        self.json_payload = json
+        return self.response
+
+
+@pytest.mark.asyncio
+async def test_openai_review_generator_parses_structured_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(review_service.httpx, "AsyncClient", FakeAsyncClient)
+    generator = OpenAIReviewGenerator(
+        api_key="test-key",
+        model="gpt-test",
+        base_url="https://api.openai.com/v1",
+        timeout_seconds=5.0,
+    )
+
+    sections = await generator.generate(
+        ReviewInput(
+            pr_number=9,
+            title="Add OpenAI integration",
+            body="PR body",
+            additions=10,
+            deletions=2,
+            changed_files=["app/reviewer.py"],
+            head_sha="abc123",
+        )
+    )
+
+    assert sections.summary == "LLM summary"
+    assert sections.findings == ["One"]
+    assert sections.open_questions == ["Question?"]
+
+
+@pytest.mark.asyncio
+async def test_openai_review_generator_wraps_http_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error = review_service.httpx.HTTPStatusError(
+        "bad request",
+        request=review_service.httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+        response=review_service.httpx.Response(400),
+    )
+    FakeAsyncClient.response = FakeResponse({}, raise_error=error)
+    monkeypatch.setattr(review_service.httpx, "AsyncClient", FakeAsyncClient)
+    generator = OpenAIReviewGenerator(api_key="test-key")
+
+    with pytest.raises(ReviewGenerationError):
+        await generator.generate(
+            ReviewInput(
+                pr_number=9,
+                title="Add OpenAI integration",
+                body="PR body",
+                additions=10,
+                deletions=2,
+                changed_files=["app/reviewer.py"],
+                head_sha="abc123",
+            )
+        )

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -1,10 +1,28 @@
 """Tests for reviewer output formatting."""
 from __future__ import annotations
 
+import pytest
+
 import app.reviewer as reviewer
+from app.review_service import ReviewGenerationError, ReviewSections
 
 
-def test_build_review_comment_formats_structured_summary() -> None:
+class FakeGenerator:
+    async def generate(self, review_input) -> ReviewSections:
+        return ReviewSections(
+            summary=f"LLM summary for {review_input.title}",
+            findings=["Check branch protection coverage."],
+            open_questions=["Should this be split into smaller commits?"],
+        )
+
+
+class BrokenGenerator:
+    async def generate(self, review_input) -> ReviewSections:
+        raise ReviewGenerationError("service unavailable")
+
+
+@pytest.mark.asyncio
+async def test_build_review_comment_formats_structured_summary() -> None:
     pull_request = {
         "number": 18,
         "title": "Add structured review summaries",
@@ -17,7 +35,7 @@ def test_build_review_comment_formats_structured_summary() -> None:
         {"filename": "tests/test_reviewer.py"},
     ]
 
-    comment = reviewer.build_review_comment(
+    comment = await reviewer.build_review_comment(
         pull_request,
         changed_files,
         head_sha="abc123",
@@ -31,18 +49,48 @@ def test_build_review_comment_formats_structured_summary() -> None:
     assert "Primary areas: app, tests." in comment
 
 
-def test_build_review_comment_falls_back_to_placeholder_when_generation_fails(
+@pytest.mark.asyncio
+async def test_build_review_comment_uses_llm_generator_when_available() -> None:
+    comment = await reviewer.build_review_comment(
+        {"number": 20, "title": "Adopt review service"},
+        [{"filename": "app/review_service.py"}],
+        head_sha="llm123",
+        generator=FakeGenerator(),
+    )
+
+    assert "LLM summary for Adopt review service" in comment
+    assert "Check branch protection coverage." in comment
+    assert "Should this be split into smaller commits?" in comment
+
+
+@pytest.mark.asyncio
+async def test_build_review_comment_falls_back_to_deterministic_review_on_generator_error() -> None:
+    comment = await reviewer.build_review_comment(
+        {"number": 21, "title": "Keep fallback path alive", "additions": 9, "deletions": 1},
+        [{"filename": "app/worker.py"}],
+        head_sha="fallback-sections",
+        generator=BrokenGenerator(),
+    )
+
+    assert comment.startswith("PRahari review summary")
+    assert "Keep fallback path alive" in comment
+    assert "Should retry behavior or stale-job handling change for this path?" in comment
+
+
+@pytest.mark.asyncio
+async def test_build_review_comment_falls_back_to_placeholder_when_generation_fails(
     monkeypatch,
 ) -> None:
     def broken_summary(*args: object, **kwargs: object) -> str:
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(reviewer, "_build_structured_review_comment", broken_summary)
+    monkeypatch.setattr(reviewer, "_build_structured_review_sections", broken_summary)
 
-    comment = reviewer.build_review_comment(
+    comment = await reviewer.build_review_comment(
         {"number": 19},
         [],
         head_sha="fallback-sha",
+        generator=BrokenGenerator(),
     )
 
     assert comment == "Review pipeline connected successfully for this PR head SHA fallback-sha"

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -19,6 +19,7 @@ def _make_signature(payload: bytes, secret: str) -> str:
 
 @pytest.mark.asyncio
 async def test_webhook_ignores_non_pr_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(wh.settings, "github_webhook_secret", "")
     enqueue_mock = Mock(return_value={"status": "ignored"})
     monkeypatch.setattr(wh, "enqueue_pull_request_event", enqueue_mock)
 
@@ -38,6 +39,7 @@ async def test_webhook_ignores_non_pr_event(monkeypatch: pytest.MonkeyPatch) -> 
 
 @pytest.mark.asyncio
 async def test_webhook_queues_pr_opened_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(wh.settings, "github_webhook_secret", "")
     payload = {
         "action": "opened",
         "number": 42,
@@ -93,6 +95,7 @@ async def test_webhook_queues_pr_opened_event(monkeypatch: pytest.MonkeyPatch) -
 
 @pytest.mark.asyncio
 async def test_webhook_queues_pr_synchronize_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(wh.settings, "github_webhook_secret", "")
     payload = {
         "action": "synchronize",
         "number": 7,
@@ -118,6 +121,7 @@ async def test_webhook_queues_pr_synchronize_event(monkeypatch: pytest.MonkeyPat
 
 @pytest.mark.asyncio
 async def test_webhook_queues_pr_reopened_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(wh.settings, "github_webhook_secret", "")
     payload = {
         "action": "reopened",
         "number": 9,
@@ -143,6 +147,7 @@ async def test_webhook_queues_pr_reopened_event(monkeypatch: pytest.MonkeyPatch)
 
 @pytest.mark.asyncio
 async def test_webhook_ignores_pr_closed_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(wh.settings, "github_webhook_secret", "")
     payload = {"action": "closed", "number": 1, "repository": {"full_name": "org/repo"}}
     enqueue_mock = Mock(return_value={"status": "ignored"})
     monkeypatch.setattr(wh, "enqueue_pull_request_event", enqueue_mock)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -129,7 +129,7 @@ async def test_worker_uses_placeholder_comment_when_review_generation_fails(
     def broken_review(*args: object, **kwargs: object) -> str:
         raise RuntimeError("review generation failed")
 
-    monkeypatch.setattr(reviewer, "_build_structured_review_comment", broken_review)
+    monkeypatch.setattr(reviewer, "_build_structured_review_sections", broken_review)
 
     processed = await process_next_job(repository=repository, client=client)
 


### PR DESCRIPTION
## Summary
- add a dedicated review service boundary for OpenAI-backed review generation
- keep reviewer orchestration in pp/reviewer.py with deterministic fallback behavior
- document and test the new review provider configuration path

## Testing
- python -m pytest tests -q