### PR TITLE
Skip stale review results before posting

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ The `review_jobs` table stores:
 - `retry_count`, `max_retries`, and `last_error`
 - `created_at`, `updated_at`, `claimed_at`, `completed_at`, and `failed_at`
 
+Job statuses currently include `pending`, `processing`, `completed`, `failed`,
+and `stale`. Stale jobs are terminal skips used when a pull request head SHA has
+changed before the worker posts its generated review comment.
+
 Dedup is enforced with a unique index on `(job_type, repo, pr_number, head_sha)`.
 That prevents repeated webhook deliveries for the same PR head SHA from creating
 duplicate review jobs while still allowing a new job when the head SHA changes.
@@ -130,7 +134,8 @@ Supported `pull_request` webhook events create rows in `review_jobs`.
 The worker polls for the oldest `pending` job, marks it `processing`, fetches
 the pull request and changed files from GitHub, checks for an existing review
 comment from the authenticated reviewer for the same SHA, generates a structured
-review summary comment, and then marks the job `completed` or `failed`.
+review summary comment, re-checks the pull request head SHA immediately before
+posting, and then marks the job `completed`, `stale`, or `failed`.
 
 By default, review generation stays deterministic. Set `REVIEW_PROVIDER=openai`
 and provide `OPENAI_API_KEY` to enable the OpenAI-backed reviewer. If the API

--- a/app/business/worker.py
+++ b/app/business/worker.py
@@ -69,6 +69,24 @@ async def process_review_job(
             changed_files,
             head_sha=job.head_sha,
         )
+        current_pull_request = await github.get_pull_request(owner, repo_name, job.pr_number)
+        current_head_sha = _get_pull_request_head_sha(current_pull_request)
+        if current_head_sha != job.head_sha:
+            stale_reason = (
+                "Skipped review because the PR head advanced before posting: "
+                f"expected {job.head_sha}, found {current_head_sha}."
+            )
+            stale_job = review_jobs.mark_job_stale(job.job_id, stale_reason)
+            logger.info(
+                "worker.process_job.skipped_stale_result",
+                job_id=job.job_id,
+                repo=job.repo,
+                pr_number=job.pr_number,
+                head_sha=job.head_sha,
+                current_head_sha=current_head_sha,
+            )
+            return stale_job
+
         await github.post_issue_comment(owner, repo_name, job.pr_number, comment_body)
         completed_job = review_jobs.mark_job_completed(job.job_id)
         logger.info(
@@ -156,3 +174,12 @@ def _has_existing_review_for_sha(
             return True
 
     return False
+
+
+def _get_pull_request_head_sha(pull_request: dict) -> str:
+    head = pull_request.get("head") or {}
+    head_sha = str(head.get("sha") or "")
+    if not head_sha:
+        raise ValueError("GitHub pull request response did not include head.sha")
+
+    return head_sha

--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -7,6 +7,7 @@ from .review_jobs import (
     PENDING_STATUS,
     PROCESSING_STATUS,
     REVIEW_JOB_TYPE,
+    STALE_STATUS,
     ReviewJob,
     ReviewJobRepository,
 )
@@ -17,6 +18,7 @@ __all__ = [
     "PENDING_STATUS",
     "PROCESSING_STATUS",
     "REVIEW_JOB_TYPE",
+    "STALE_STATUS",
     "ReviewJob",
     "ReviewJobRepository",
     "get_connection",

--- a/app/database/review_jobs.py
+++ b/app/database/review_jobs.py
@@ -12,6 +12,7 @@ PENDING_STATUS = "pending"
 PROCESSING_STATUS = "processing"
 COMPLETED_STATUS = "completed"
 FAILED_STATUS = "failed"
+STALE_STATUS = "stale"
 
 
 @dataclass(slots=True)
@@ -159,6 +160,15 @@ class ReviewJobRepository:
             terminal_column="failed_at",
             last_error=error_message,
             increment_retry_count=True,
+        )
+
+    def mark_job_stale(self, job_id: str, reason: str) -> ReviewJob:
+        """Mark a processing job as stale without treating it as a failure."""
+        return self._update_job_status(
+            job_id=job_id,
+            status=STALE_STATUS,
+            terminal_column="completed_at",
+            last_error=reason,
         )
 
     def _update_job_status(

--- a/tests/business/test_worker.py
+++ b/tests/business/test_worker.py
@@ -10,7 +10,12 @@ from app.business.reviewer import build_review_comment_marker
 from app.business.reviewer_identity import ReviewerIdentityProvider
 from app.business.worker import process_next_job
 from app.database.connection import initialize_database
-from app.database.review_jobs import COMPLETED_STATUS, FAILED_STATUS, ReviewJobRepository
+from app.database.review_jobs import (
+    COMPLETED_STATUS,
+    FAILED_STATUS,
+    STALE_STATUS,
+    ReviewJobRepository,
+)
 from app.services.github_client import Client, JsonDict, JsonList
 
 
@@ -21,10 +26,12 @@ class FakeGitHubClient(Client):
         fail_on_comment: bool = False,
         existing_comments: list[dict[str, object]] | None = None,
         authenticated_login: str = "prahari-bot",
+        pull_request_head_shas: list[str] | None = None,
     ) -> None:
         self.fail_on_comment = fail_on_comment
         self.existing_comments = existing_comments or []
         self.authenticated_login = authenticated_login
+        self.pull_request_head_shas = list(pull_request_head_shas or ["abc123"])
         self.auth_calls = 0
         self.fetch_calls: list[tuple[str, str, int]] = []
         self.comments_fetch_calls: list[tuple[str, str, int]] = []
@@ -33,11 +40,13 @@ class FakeGitHubClient(Client):
 
     async def get_pull_request(self, owner: str, repo: str, pr_number: int) -> JsonDict:
         self.fetch_calls.append((owner, repo, pr_number))
+        head_sha = self.pull_request_head_shas[min(len(self.fetch_calls) - 1, len(self.pull_request_head_shas) - 1)]
         return {
             "number": pr_number,
             "title": "Add structured PR review summary",
             "additions": 42,
             "deletions": 7,
+            "head": {"sha": head_sha},
         }
 
     async def list_pull_request_files(
@@ -78,14 +87,14 @@ async def test_worker_claims_one_pending_job_and_posts_comment(tmp_path: Path) -
         pr_number=14,
         head_sha="abc123",
     )
-    client = FakeGitHubClient()
+    client = FakeGitHubClient(pull_request_head_shas=["abc123", "abc123"])
 
     processed = await process_next_job(repository=repository, client=client)
 
     assert processed is not None
     assert processed.job_id == job.job_id
     assert processed.status == COMPLETED_STATUS
-    assert client.fetch_calls == [("AjayvirS", "PRahari", 14)]
+    assert client.fetch_calls == [("AjayvirS", "PRahari", 14), ("AjayvirS", "PRahari", 14)]
     assert client.comments_fetch_calls == [("AjayvirS", "PRahari", 14)]
     assert client.auth_calls == 1
     assert client.files_calls == [("AjayvirS", "PRahari", 14)]
@@ -108,7 +117,10 @@ async def test_worker_marks_job_failed_on_error(tmp_path: Path) -> None:
         pr_number=15,
         head_sha="deadbeef",
     )
-    client = FakeGitHubClient(fail_on_comment=True)
+    client = FakeGitHubClient(
+        fail_on_comment=True,
+        pull_request_head_shas=["deadbeef", "deadbeef"],
+    )
 
     processed = await process_next_job(repository=repository, client=client)
 
@@ -128,7 +140,7 @@ async def test_worker_does_not_process_same_job_twice(tmp_path: Path) -> None:
         pr_number=16,
         head_sha="once-only",
     )
-    client = FakeGitHubClient()
+    client = FakeGitHubClient(pull_request_head_shas=["once-only", "once-only"])
 
     first = await process_next_job(repository=repository, client=client)
     second = await process_next_job(repository=repository, client=client)
@@ -159,7 +171,8 @@ async def test_worker_skips_generation_when_duplicate_review_comment_exists(
                 ),
                 "user": {"login": "prahari-bot"},
             }
-        ]
+        ],
+        pull_request_head_shas=["already-reviewed"],
     )
 
     async def broken_review(*args: object, **kwargs: object) -> str:
@@ -204,13 +217,15 @@ async def test_worker_does_not_skip_when_marker_matches_but_login_does_not(
                 ),
                 "user": {"login": "some-other-user"},
             }
-        ]
+        ],
+        pull_request_head_shas=["mismatch-sha", "mismatch-sha"],
     )
 
     processed = await process_next_job(repository=repository, client=client)
 
     assert processed is not None
     assert processed.status == COMPLETED_STATUS
+    assert client.fetch_calls == [("AjayvirS", "PRahari", 19), ("AjayvirS", "PRahari", 19)]
     assert client.files_calls == [("AjayvirS", "PRahari", 19)]
     assert len(client.comment_calls) == 1
 
@@ -227,7 +242,7 @@ async def test_worker_uses_placeholder_comment_when_review_generation_fails(
         pr_number=17,
         head_sha="fallback123",
     )
-    client = FakeGitHubClient()
+    client = FakeGitHubClient(pull_request_head_shas=["fallback123", "fallback123"])
 
     def broken_review(*args: object, **kwargs: object) -> str:
         raise RuntimeError("review generation failed")
@@ -243,3 +258,36 @@ async def test_worker_uses_placeholder_comment_when_review_generation_fails(
         "Review pipeline connected successfully for this PR head SHA fallback123\n\n"
         "<!-- prahari:review head_sha=fallback123 -->"
     )
+
+
+@pytest.mark.asyncio
+async def test_worker_skips_posting_when_pr_head_advances_during_processing(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "review-jobs.db"
+    initialize_database(str(database_path))
+    repository = ReviewJobRepository(str(database_path))
+    job, _ = repository.insert_review_job(
+        repo="AjayvirS/PRahari",
+        pr_number=20,
+        head_sha="sha-before-review",
+    )
+    client = FakeGitHubClient(
+        pull_request_head_shas=["sha-before-review", "sha-after-review"],
+    )
+
+    processed = await process_next_job(repository=repository, client=client)
+
+    assert processed is not None
+    assert processed.job_id == job.job_id
+    assert processed.status == STALE_STATUS
+    assert processed.completed_at is not None
+    assert processed.failed_at is None
+    assert processed.last_error == (
+        "Skipped review because the PR head advanced before posting: "
+        "expected sha-before-review, found sha-after-review."
+    )
+    assert client.fetch_calls == [("AjayvirS", "PRahari", 20), ("AjayvirS", "PRahari", 20)]
+    assert client.comments_fetch_calls == [("AjayvirS", "PRahari", 20)]
+    assert client.files_calls == [("AjayvirS", "PRahari", 20)]
+    assert client.comment_calls == []

--- a/tests/database/test_review_jobs.py
+++ b/tests/database/test_review_jobs.py
@@ -11,6 +11,7 @@ from app.database.review_jobs import (
     PENDING_STATUS,
     PROCESSING_STATUS,
     REVIEW_JOB_TYPE,
+    STALE_STATUS,
     ReviewJobRepository,
 )
 
@@ -135,7 +136,7 @@ def test_claim_next_pending_job_marks_it_processing(tmp_path: Path) -> None:
     assert claimed.claimed_at is not None
 
 
-def test_completed_and_failed_jobs_are_marked_terminally(tmp_path: Path) -> None:
+def test_completed_failed_and_stale_jobs_are_marked_terminally(tmp_path: Path) -> None:
     database_path = tmp_path / "review-jobs.db"
     initialize_database(str(database_path))
     repository = ReviewJobRepository(str(database_path))
@@ -168,3 +169,22 @@ def test_completed_and_failed_jobs_are_marked_terminally(tmp_path: Path) -> None
     assert failed.failed_at is not None
     assert failed.last_error == "boom"
     assert failed.retry_count == 1
+
+    stale_seed, _ = repository.insert_review_job(
+        repo="AjayvirS/PRahari",
+        pr_number=32,
+        head_sha="stale",
+    )
+    claimed_for_stale = repository.claim_next_pending_job()
+    assert claimed_for_stale is not None
+    assert claimed_for_stale.job_id == stale_seed.job_id
+
+    stale = repository.mark_job_stale(
+        claimed_for_stale.job_id,
+        "Skipped review because the PR head advanced before posting.",
+    )
+    assert stale.status == STALE_STATUS
+    assert stale.completed_at is not None
+    assert stale.failed_at is None
+    assert stale.last_error == "Skipped review because the PR head advanced before posting."
+    assert stale.retry_count == 0


### PR DESCRIPTION
## Summary
- add a final PR head SHA check immediately before posting the generated review comment
- record stale review jobs with an explicit non-failure `stale` status and reason
- cover the stale-result worker path and repository status handling with tests

## Testing
- .\\.venv\\Scripts\\python.exe -m pytest tests -q

Refs #11